### PR TITLE
Build only master or develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ services:
 
 before_script: 
   - python3 -m unittest
+  
+branches:
+  only: 
+    - master
+    - develop
 
 script:
   - docker build .


### PR DESCRIPTION
Do not merge pushes on other branches than master or develop. Added to prevent
double build on PRs of feature branches.